### PR TITLE
feature: setup motor max_power configuration

### DIFF
--- a/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
+++ b/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
@@ -98,6 +98,7 @@ private:
 	int rate;
 	int amp_lim;
 	int max_rpm;
+	int max_power;
 	int motor_acceleration_rate;
 	
 	bool safe_speed;
@@ -214,6 +215,15 @@ RoboteqDriver::RoboteqDriver(ros::NodeHandle nh, ros::NodeHandle nh_priv) : nh_(
 	{
 		ROS_ERROR_STREAM(tag << "Failed to set closed loope error detetection.");
 		exit(EXIT_FAILURE);
+	}
+	if (nh_.hasParam("max_power"))
+	{
+		nh_.getParam("max_power", max_power);
+		if (!setup("MXPW", max_power))
+		{
+			ROS_ERROR_STREAM(tag << "Failed to set max power.");
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	// Advertise services


### PR DESCRIPTION
This pull request adds support for configuring the motor controller's maximum power limit via a new `max_power` parameter in the `RoboteqDriver` class. The driver will now read the `max_power` parameter from the ROS parameter server and apply it to the hardware if specified.

Parameter and configuration enhancements:

* Added a new `max_power` member variable to the `RoboteqDriver` class to store the maximum power setting.
* Updated the constructor to check for the `max_power` parameter, retrieve its value, and apply it to the motor controller using the `setup("MXPW", max_power)` command. If this setup fails, the node will log an error and exit.