### PR TITLE
Release/v1.2.1

### DIFF
--- a/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
+++ b/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
@@ -98,6 +98,7 @@ private:
 	int rate;
 	int amp_lim;
 	int max_rpm;
+	int max_power;
 	int motor_acceleration_rate;
 	
 	bool safe_speed;
@@ -214,6 +215,15 @@ RoboteqDriver::RoboteqDriver(ros::NodeHandle nh, ros::NodeHandle nh_priv) : nh_(
 	{
 		ROS_ERROR_STREAM(tag << "Failed to set closed loope error detetection.");
 		exit(EXIT_FAILURE);
+	}
+	if (nh_.hasParam("max_power"))
+	{
+		nh_.getParam("max_power", max_power);
+		if (!setup("MXPW", max_power))
+		{
+			ROS_ERROR_STREAM(tag << "Failed to set max power.");
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	// Advertise services


### PR DESCRIPTION
This pull request adds support for configuring the maximum power limit of the Roboteq motor controller via a new `max_power` parameter. The main changes allow the user to specify `max_power` in the ROS parameter server, which is then set on the device during driver initialization.

**Parameter and configuration enhancements:**

* Added a new `max_power` member variable to the `RoboteqDriver` class to store the maximum power setting.
* Updated the constructor of `RoboteqDriver` to check for a `max_power` parameter, retrieve its value, and configure the hardware using the `setup("MXPW", max_power)` command. If the setup fails, an error is logged and the node exits.