### PR TITLE
optionally set motor deceleration rate

### DIFF
--- a/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
+++ b/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
@@ -227,6 +227,7 @@ private:
 	int amp_trig;
 	int max_power;
 	int motor_acceleration_rate;
+	int motor_deceleration_rate;
 	
 	bool safe_speed;
 	
@@ -360,6 +361,15 @@ RoboteqDriver::RoboteqDriver(ros::NodeHandle nh, ros::NodeHandle nh_priv) : nh_(
 		if (!setup("ATRIG", amp_trig))
 		{
 			ROS_ERROR_STREAM(tag << "Failed to set Amp trigger level.");
+			exit(EXIT_FAILURE);
+		}
+	}
+	if (nh_.hasParam("motor_deceleration_rate"))
+	{
+		nh_.getParam("motor_deceleration_rate", motor_deceleration_rate);
+		if (!setup("MDEC", motor_deceleration_rate))
+		{
+			ROS_ERROR_STREAM(tag << "Failed to set motor deceleration rate.");
 			exit(EXIT_FAILURE);
 		}
 	}


### PR DESCRIPTION
This pull request introduces support for configuring the motor deceleration rate in the `RoboteqDriver` node. The main changes add a new parameter for deceleration rate, allowing it to be set via ROS parameters, and ensure it is properly initialized and validated during node startup.

**Parameter handling improvements:**

* Added a new member variable `motor_deceleration_rate` to the `RoboteqDriver` class to store the motor deceleration rate parameter.
* Updated the constructor to check for the `motor_deceleration_rate` ROS parameter, retrieve its value, and configure the controller using the `setup` method. If setup fails, the node logs an error and exits.