### PR TITLE
Release/v1.3.0

### DIFF
--- a/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
+++ b/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
@@ -227,6 +227,7 @@ private:
 	int amp_trig;
 	int max_power;
 	int motor_acceleration_rate;
+	int motor_deceleration_rate;
 	
 	bool safe_speed;
 	
@@ -360,6 +361,15 @@ RoboteqDriver::RoboteqDriver(ros::NodeHandle nh, ros::NodeHandle nh_priv) : nh_(
 		if (!setup("ATRIG", amp_trig))
 		{
 			ROS_ERROR_STREAM(tag << "Failed to set Amp trigger level.");
+			exit(EXIT_FAILURE);
+		}
+	}
+	if (nh_.hasParam("motor_deceleration_rate"))
+	{
+		nh_.getParam("motor_deceleration_rate", motor_deceleration_rate);
+		if (!setup("MDEC", motor_deceleration_rate))
+		{
+			ROS_ERROR_STREAM(tag << "Failed to set motor deceleration rate.");
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
+++ b/ROS-Driver-Update/roboteq_motor_controller_driver/src/roboteq_motor_controller_driver_node.cpp
@@ -527,13 +527,13 @@ void RoboteqDriver::setup_subscribers()
 		nh_.param<double>("reduction_ratio", reduction_ratio, 70.0);
 		nh_.param<double>("wheel_circumference", wheel_circumference, 1.13914122);		
 		ROS_INFO_STREAM("Driver controls two motors moving a skid steering vehicle.");
-		cmd_vel_sub = nh_.subscribe("cmd_vel", 10, &RoboteqDriver::skid_steering_vel_callback, this);
+		cmd_vel_sub = nh_.subscribe("cmd_vel", 1, &RoboteqDriver::skid_steering_vel_callback, this);
 	}
 	else if (channel_mode == "dual")
 	{
 		ROS_INFO_STREAM("Driver controls two motors with a single value.");
-		cmd_vel_channel_1_sub = nh_.subscribe("dual_cmd_vel", 10, &RoboteqDriver::channel_1_vel_callback, this);
-		cmd_vel_channel_2_sub = nh_.subscribe("dual_cmd_vel", 10, &RoboteqDriver::channel_2_vel_callback, this);
+		cmd_vel_channel_1_sub = nh_.subscribe("dual_cmd_vel", 1, &RoboteqDriver::channel_1_vel_callback, this);
+		cmd_vel_channel_2_sub = nh_.subscribe("dual_cmd_vel", 1, &RoboteqDriver::channel_2_vel_callback, this);
 		if ((motor_1_type == "set_speed") || (motor_type == "set_speed"))
 		{
 			ROS_INFO_STREAM("Motor 1 is operating in closed loop mode.");
@@ -557,22 +557,22 @@ void RoboteqDriver::setup_subscribers()
 		if (motor_1_type == "set_speed")
 		{
 			ROS_INFO_STREAM("Motor 1 is operating in closed loop mode.");
-			cmd_vel_channel_1_sub = nh_.subscribe("chan_1_set_vel", 10, &RoboteqDriver::channel_1_vel_callback, this);
+			cmd_vel_channel_1_sub = nh_.subscribe("chan_1_set_vel", 1, &RoboteqDriver::channel_1_vel_callback, this);
 		}
 		else
 		{
 			ROS_INFO_STREAM("Motor 1 is operating in open loop mode.");
-			cmd_vel_channel_1_sub = nh_.subscribe("chan_1_go_to_vel", 10, &RoboteqDriver::channel_1_vel_callback, this);
+			cmd_vel_channel_1_sub = nh_.subscribe("chan_1_go_to_vel", 1, &RoboteqDriver::channel_1_vel_callback, this);
 		}
 		if (motor_2_type == "set_speed")
 		{
 			ROS_INFO_STREAM("Motor 2 is operating in closed loop mode.");
-			cmd_vel_channel_2_sub = nh_.subscribe("chan_2_set_vel", 10, &RoboteqDriver::channel_2_vel_callback, this);
+			cmd_vel_channel_2_sub = nh_.subscribe("chan_2_set_vel", 1, &RoboteqDriver::channel_2_vel_callback, this);
 		}
 		else
 		{
 			ROS_INFO_STREAM("Motor 2 is operating in open loop mode.");
-			cmd_vel_channel_2_sub = nh_.subscribe("chan_2_go_to_vel", 10, &RoboteqDriver::channel_2_vel_callback, this);
+			cmd_vel_channel_2_sub = nh_.subscribe("chan_2_go_to_vel", 1, &RoboteqDriver::channel_2_vel_callback, this);
 		}
 	}
 }


### PR DESCRIPTION
This pull request updates the `roboteq_motor_controller_driver_node.cpp` to add support for configuring the motor deceleration rate and to reduce the queue size for all ROS command velocity subscribers from 10 to 1. These changes improve the driver's configurability and responsiveness to new velocity commands.

**Parameter and configuration enhancements:**

* Added a new `motor_deceleration_rate` parameter to the `RoboteqDriver` class, including logic to read this parameter from the ROS parameter server and set it on the motor controller. [[1]](diffhunk://#diff-5fbcb922ad6b8643b73e5b6fc18c3f92a49ef7bf5420fcced56ce6bf76cb5a37R230) [[2]](diffhunk://#diff-5fbcb922ad6b8643b73e5b6fc18c3f92a49ef7bf5420fcced56ce6bf76cb5a37R367-R375)

**Subscriber responsiveness improvements:**

* Reduced the queue size for all velocity command subscribers (e.g., `cmd_vel`, `dual_cmd_vel`, `chan_1_set_vel`, `chan_1_go_to_vel`, `chan_2_set_vel`, `chan_2_go_to_vel`) from 10 to 1, ensuring that the most recent command is always processed and reducing command latency. [[1]](diffhunk://#diff-5fbcb922ad6b8643b73e5b6fc18c3f92a49ef7bf5420fcced56ce6bf76cb5a37L530-R546) [[2]](diffhunk://#diff-5fbcb922ad6b8643b73e5b6fc18c3f92a49ef7bf5420fcced56ce6bf76cb5a37L560-R585)